### PR TITLE
feat(tasks): add base task CRUD endpoints with DTO validation

### DIFF
--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -61,12 +61,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
         exception.message,
       );
 
+      let errorCode: string = ERROR_CODES.INTERNAL_ERROR;
+
+      if (statusCode === 400) {
+        errorCode = ERROR_CODES.VALIDATION_ERROR;
+      } else if (statusCode === 404) {
+        errorCode = ERROR_CODES.NOT_FOUND;
+      }
+
       return {
         statusCode,
-        error:
-          statusCode === 400
-            ? ERROR_CODES.VALIDATION_ERROR
-            : ERROR_CODES.INTERNAL_ERROR,
+        error: errorCode,
         message,
         timestamp: new Date().toISOString(),
         path,

--- a/src/modules/tasks/dto/create-task.dto.ts
+++ b/src/modules/tasks/dto/create-task.dto.ts
@@ -1,0 +1,38 @@
+/**
+ * DTO for creating one task from HTTP payload.
+ */
+import {
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+const TASK_STATUS_VALUES = ['TODO', 'IN_PROGRESS', 'DONE'] as const;
+
+type TaskStatusValue = (typeof TASK_STATUS_VALUES)[number];
+
+export class CreateTaskDto {
+  /**
+   * Task title shown to users.
+   */
+  @IsString()
+  @MinLength(3)
+  @MaxLength(120)
+  public readonly title!: string;
+
+  /**
+   * Task description with acceptance context.
+   */
+  @IsString()
+  @MaxLength(200)
+  public readonly description!: string;
+
+  /**
+   * Optional status at creation time.
+   */
+  @IsOptional()
+  @IsIn(TASK_STATUS_VALUES)
+  public readonly status?: TaskStatusValue;
+}

--- a/src/modules/tasks/dto/list-tasks-query.dto.ts
+++ b/src/modules/tasks/dto/list-tasks-query.dto.ts
@@ -1,0 +1,17 @@
+/**
+ * DTO for listing tasks with optional sorting criteria.
+ */
+import { IsIn, IsOptional } from 'class-validator';
+
+const LIST_SORT_VALUES = ['ice'] as const;
+
+type ListSortValue = (typeof LIST_SORT_VALUES)[number];
+
+export class ListTasksQueryDto {
+  /**
+   * Optional sorting mode.
+   */
+  @IsOptional()
+  @IsIn(LIST_SORT_VALUES)
+  public readonly sort?: ListSortValue;
+}

--- a/src/modules/tasks/dto/update-task.dto.ts
+++ b/src/modules/tasks/dto/update-task.dto.ts
@@ -1,0 +1,70 @@
+/**
+ * DTO for partial task updates from HTTP payload.
+ */
+import {
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+const TASK_STATUS_VALUES = ['TODO', 'IN_PROGRESS', 'DONE'] as const;
+
+type TaskStatusValue = (typeof TASK_STATUS_VALUES)[number];
+
+export class UpdateTaskDto {
+  /**
+   * Optional task title update.
+   */
+  @IsOptional()
+  @IsString()
+  @MinLength(3)
+  @MaxLength(120)
+  public readonly title?: string;
+
+  /**
+   * Optional task description update.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  public readonly description?: string;
+
+  /**
+   * Optional task status update.
+   */
+  @IsOptional()
+  @IsIn(TASK_STATUS_VALUES)
+  public readonly status?: TaskStatusValue;
+
+  /**
+   * Optional ICE impact update.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  public readonly impact?: number;
+
+  /**
+   * Optional ICE confidence update.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  public readonly confidence?: number;
+
+  /**
+   * Optional ICE effort update.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  public readonly effort?: number;
+}

--- a/src/modules/tasks/ports/task-repository.port.ts
+++ b/src/modules/tasks/ports/task-repository.port.ts
@@ -20,7 +20,7 @@ export interface TaskRecord {
 export interface CreateTaskInput {
   readonly title: string;
   readonly description: string;
-  readonly status: 'TODO' | 'IN_PROGRESS' | 'DONE';
+  readonly status?: 'TODO' | 'IN_PROGRESS' | 'DONE';
 }
 
 export interface UpdateTaskInput {

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,7 +1,22 @@
 /**
  * Exposes base HTTP routes for task operations.
  */
-import { Controller, Get } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import type { TaskRecord } from './ports/task-repository.port';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { ListTasksQueryDto } from './dto/list-tasks-query.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
 import { TasksService } from './tasks.service';
 
 @Controller('tasks')
@@ -11,6 +26,62 @@ export class TasksController {
    * @param tasksService Service that orchestrates task use cases.
    */
   public constructor(private readonly tasksService: TasksService) {}
+
+  /**
+   * Creates one task from HTTP payload.
+   * @param createTaskDto Task creation payload.
+   * @returns Created task.
+   */
+  @Post()
+  public createTask(@Body() createTaskDto: CreateTaskDto): Promise<TaskRecord> {
+    return this.tasksService.createTask(createTaskDto);
+  }
+
+  /**
+   * Lists tasks with optional sorting criteria.
+   * @param queryDto Query payload.
+   * @returns List of tasks.
+   */
+  @Get()
+  public listTasks(
+    @Query() queryDto: ListTasksQueryDto,
+  ): Promise<TaskRecord[]> {
+    return this.tasksService.listTasks(queryDto.sort);
+  }
+
+  /**
+   * Gets one task by identifier.
+   * @param id Task identifier.
+   * @returns Found task.
+   */
+  @Get(':id')
+  public getTaskById(@Param('id') id: string): Promise<TaskRecord> {
+    return this.tasksService.getTaskByIdOrThrow(id);
+  }
+
+  /**
+   * Applies partial task updates.
+   * @param id Task identifier.
+   * @param updateTaskDto Partial task payload.
+   * @returns Updated task.
+   */
+  @Patch(':id')
+  public updateTask(
+    @Param('id') id: string,
+    @Body() updateTaskDto: UpdateTaskDto,
+  ): Promise<TaskRecord> {
+    return this.tasksService.updateTask(id, updateTaskDto);
+  }
+
+  /**
+   * Deletes one task by identifier.
+   * @param id Task identifier.
+   */
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  public async deleteTask(@Param('id') id: string): Promise<void> {
+    await this.tasksService.deleteTask(id);
+  }
 
   /**
    * Provides a minimal endpoint to validate module mounting.

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -1,12 +1,14 @@
 /**
  * Orchestrates task-related use cases for the Tasks module.
  */
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { TASK_REPOSITORY_PORT } from './ports/task-repository.port';
 import type {
   CreateTaskInput,
+  ListTasksSort,
   TaskRecord,
   TaskRepositoryPort,
+  UpdateTaskInput,
 } from './ports/task-repository.port';
 
 @Injectable()
@@ -26,16 +28,65 @@ export class TasksService {
    * @returns Newly created task record.
    */
   public async createTask(taskData: CreateTaskInput): Promise<TaskRecord> {
-    return this.taskRepositoryPort.create(taskData);
+    return this.taskRepositoryPort.create({
+      ...taskData,
+      status: taskData.status ?? 'TODO',
+    });
   }
 
   /**
-   * Finds one task by id using repository abstraction.
-   * @param id Task identifier.
-   * @returns Task record or null when absent.
+   * Lists tasks using optional sorting criteria.
+   * @param sort Optional list sorting criteria.
+   * @returns Task list.
    */
-  public async getTaskById(id: string): Promise<TaskRecord | null> {
-    return this.taskRepositoryPort.findById(id);
+  public async listTasks(sort?: ListTasksSort): Promise<TaskRecord[]> {
+    return this.taskRepositoryPort.findAll(sort);
+  }
+
+  /**
+   * Finds one task by id and throws when absent.
+   * @param id Task identifier.
+   * @returns Existing task record.
+   */
+  public async getTaskByIdOrThrow(id: string): Promise<TaskRecord> {
+    const task = await this.taskRepositoryPort.findById(id);
+
+    if (task === null) {
+      throw new NotFoundException('Task not found');
+    }
+
+    return task;
+  }
+
+  /**
+   * Applies partial updates to a task.
+   * @param id Task identifier.
+   * @param updateData Partial task payload.
+   * @returns Updated task record.
+   */
+  public async updateTask(
+    id: string,
+    updateData: UpdateTaskInput,
+  ): Promise<TaskRecord> {
+    const updatedTask = await this.taskRepositoryPort.update(id, updateData);
+
+    if (updatedTask === null) {
+      throw new NotFoundException('Task not found');
+    }
+
+    return updatedTask;
+  }
+
+  /**
+   * Deletes a task and throws when absent.
+   * @param id Task identifier.
+   */
+  public async deleteTask(id: string): Promise<void> {
+    const deleted = await this.taskRepositoryPort.delete(id);
+
+    if (!deleted) {
+      throw new NotFoundException('Task not found');
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
Adds the five base CRUD endpoints for tasks: POST /tasks, GET /tasks,
GET /tasks/:id, PATCH /tasks/:id, and DELETE /tasks/:id. Introduces
CreateTaskDto, UpdateTaskDto and ListTasksQueryDto with class-validator
rules. Extends TasksService with the corresponding use cases and updates
the global exception filter to return NOT_FOUND on 404 responses.

## Issue
Closes #2

## Target Branch Policy (required)
- [x] This PR targets `dev` if it comes from `feature/*`, `fix/*`, `chore/*`, or `hotfix/*`
- [ ] This PR targets `main` only when source branch is `dev`

## Validation
- [ ] `npm run build`
- [ ] `npm run lint`
- [ ] `npm run test`

## Notes
N/A
