### PR TITLE
feat: add ai-based ice estimation flow

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -10,6 +10,11 @@ export interface AppConfiguration {
   readonly persistence: {
     readonly databaseUrl: string;
   };
+  readonly ai: {
+    readonly geminiApiKey?: string;
+    readonly geminiModel: string;
+    readonly timeoutMs: number;
+  };
 }
 
 /**
@@ -25,6 +30,11 @@ export function configuration(): AppConfiguration {
     },
     persistence: {
       databaseUrl: env.DATABASE_URL,
+    },
+    ai: {
+      geminiApiKey: env.GEMINI_API_KEY,
+      geminiModel: env.GEMINI_MODEL,
+      timeoutMs: env.AI_TIMEOUT_MS,
     },
   };
 }

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -4,6 +4,9 @@
 export interface ValidatedEnv {
   readonly PORT: number;
   readonly DATABASE_URL: string;
+  readonly GEMINI_API_KEY?: string;
+  readonly GEMINI_MODEL: string;
+  readonly AI_TIMEOUT_MS: number;
 }
 
 /**
@@ -16,6 +19,11 @@ export function validateEnv(env: NodeJS.ProcessEnv): ValidatedEnv {
   const portRaw: string = env.PORT ?? '3000';
   const port: number = Number(portRaw);
   const databaseUrl: string = env.DATABASE_URL ?? 'file:./dev.db';
+  const geminiApiKey: string | undefined =
+    env.GEMINI_API_KEY?.trim() || undefined;
+  const geminiModel: string = env.GEMINI_MODEL?.trim() || 'gemini-1.5-flash';
+  const aiTimeoutRaw: string = env.AI_TIMEOUT_MS ?? '8000';
+  const aiTimeoutMs: number = Number(aiTimeoutRaw);
 
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw new Error(
@@ -23,8 +31,17 @@ export function validateEnv(env: NodeJS.ProcessEnv): ValidatedEnv {
     );
   }
 
+  if (!Number.isInteger(aiTimeoutMs) || aiTimeoutMs <= 0) {
+    throw new Error(
+      'Invalid AI_TIMEOUT_MS value. Expected a positive integer.',
+    );
+  }
+
   return {
     PORT: port,
     DATABASE_URL: databaseUrl,
+    GEMINI_API_KEY: geminiApiKey,
+    GEMINI_MODEL: geminiModel,
+    AI_TIMEOUT_MS: aiTimeoutMs,
   };
 }

--- a/src/modules/ai/ai.service.ts
+++ b/src/modules/ai/ai.service.ts
@@ -2,6 +2,7 @@
  * Handles AI estimation integration orchestration.
  */
 import { Injectable } from '@nestjs/common';
+import type { AiEstimationResponseDto } from './dto/ai-estimation-response.dto';
 import { GeminiProvider } from './providers/gemini.provider';
 
 @Injectable()
@@ -11,6 +12,17 @@ export class AiService {
    * @param geminiProvider Provider used for remote AI communication.
    */
   public constructor(private readonly geminiProvider: GeminiProvider) {}
+
+  /**
+   * Requests an ICE estimation for a task description.
+   * @param description Task description used as AI prompt context.
+   * @returns Normalized ICE estimation returned by the provider adapter.
+   */
+  public async estimateIce(
+    description: string,
+  ): Promise<AiEstimationResponseDto> {
+    return this.geminiProvider.estimateIce(description);
+  }
 
   /**
    * Returns AI module bootstrap status.

--- a/src/modules/ai/dto/ai-estimation-response.dto.ts
+++ b/src/modules/ai/dto/ai-estimation-response.dto.ts
@@ -1,0 +1,8 @@
+/**
+ * Defines the normalized ICE estimation payload returned by the AI module.
+ */
+export interface AiEstimationResponseDto {
+  readonly impact: number;
+  readonly confidence: number;
+  readonly effort: number;
+}

--- a/src/modules/ai/providers/gemini.provider.ts
+++ b/src/modules/ai/providers/gemini.provider.ts
@@ -1,15 +1,213 @@
 /**
- * Placeholder provider that represents external Gemini API integration.
+ * Integrates with the external Gemini API to estimate ICE values from text.
  */
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { ERROR_CODES } from '../../../common/constants/error-codes';
+import { DomainException } from '../../../common/exceptions/domain.exception';
+import { configuration } from '../../../config/configuration';
+import type { AiEstimationResponseDto } from '../dto/ai-estimation-response.dto';
+
+interface GeminiResponsePart {
+  readonly text?: string;
+}
+
+interface GeminiResponseContent {
+  readonly parts?: readonly GeminiResponsePart[];
+}
+
+interface GeminiResponseCandidate {
+  readonly content?: GeminiResponseContent;
+}
+
+interface GeminiGenerateContentResponse {
+  readonly candidates?: readonly GeminiResponseCandidate[];
+}
 
 @Injectable()
 export class GeminiProvider {
+  /**
+   * Requests an ICE estimation from Gemini using the task description.
+   * @param description Task description used to build the remote prompt.
+   * @returns Parsed ICE estimation payload with integer values.
+   */
+  public async estimateIce(
+    description: string,
+  ): Promise<AiEstimationResponseDto> {
+    const aiConfig = configuration().ai;
+
+    if (aiConfig.geminiApiKey === undefined) {
+      throw new DomainException(
+        'Gemini API key is not configured',
+        ERROR_CODES.AI_UNAVAILABLE,
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    const abortController = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+      abortController.abort();
+    }, aiConfig.timeoutMs);
+
+    try {
+      const response = await fetch(
+        this.buildEndpoint(aiConfig.geminiModel, aiConfig.geminiApiKey),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [
+                  {
+                    text: this.buildPrompt(description),
+                  },
+                ],
+              },
+            ],
+          }),
+          signal: abortController.signal,
+        },
+      );
+
+      if (!response.ok) {
+        throw this.createAiUnavailableError(
+          `Gemini request failed with status ${response.status}`,
+        );
+      }
+
+      const responseBody =
+        (await response.json()) as GeminiGenerateContentResponse;
+      const responseText = this.extractResponseText(responseBody);
+
+      return this.parseEstimation(responseText);
+    } catch (error: unknown) {
+      if (error instanceof DomainException) {
+        throw error;
+      }
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw this.createAiUnavailableError('Gemini request timed out');
+      }
+
+      throw this.createAiUnavailableError('Timeout or invalid AI payload');
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+
   /**
    * Returns provider readiness during bootstrap phase.
    * @returns Provider status text.
    */
   public getStatus(): string {
     return 'Gemini provider ready';
+  }
+
+  /**
+   * Builds the Gemini generateContent endpoint for the configured model.
+   * @param model Gemini model identifier.
+   * @param apiKey Gemini API key used for authentication.
+   * @returns Fully-qualified HTTPS endpoint.
+   */
+  private buildEndpoint(model: string, apiKey: string): string {
+    return `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  }
+
+  /**
+   * Builds a strict JSON-only prompt for Gemini.
+   * @param description Task description provided by the caller.
+   * @returns Prompt text sent to the external provider.
+   */
+  private buildPrompt(description: string): string {
+    return [
+      'Estimate ICE values for the task description below.',
+      'Respond with valid JSON only, without markdown fences or extra text.',
+      'Use this exact shape: {"impact":number,"confidence":number,"effort":number}.',
+      'All values must be integers between 1 and 10.',
+      `Task description: ${description}`,
+    ].join('\n');
+  }
+
+  /**
+   * Extracts the first text part returned by Gemini.
+   * @param responseBody Raw JSON payload from the Gemini API.
+   * @returns Plain text content expected to contain a JSON object.
+   */
+  private extractResponseText(
+    responseBody: GeminiGenerateContentResponse,
+  ): string {
+    const candidate = responseBody.candidates?.[0];
+    const part = candidate?.content?.parts?.[0];
+
+    if (typeof part?.text !== 'string' || part.text.trim().length === 0) {
+      throw this.createAiUnavailableError('Invalid AI payload: missing text');
+    }
+
+    return part.text.trim();
+  }
+
+  /**
+   * Parses the provider text response into a normalized ICE estimation.
+   * @param responseText Text returned by the provider.
+   * @returns ICE estimation with integer fields.
+   */
+  private parseEstimation(responseText: string): AiEstimationResponseDto {
+    const sanitizedText = responseText
+      .replace(/^```json\s*/i, '')
+      .replace(/^```\s*/i, '')
+      .replace(/```$/i, '')
+      .trim();
+
+    try {
+      const parsed = JSON.parse(sanitizedText) as Record<string, unknown>;
+
+      return this.validateEstimationShape(parsed);
+    } catch {
+      throw this.createAiUnavailableError('Invalid AI payload: malformed JSON');
+    }
+  }
+
+  /**
+   * Validates the parsed JSON shape returned by the provider.
+   * @param parsed Raw parsed JSON object.
+   * @returns Estimation payload with numeric ICE fields.
+   */
+  private validateEstimationShape(
+    parsed: Record<string, unknown>,
+  ): AiEstimationResponseDto {
+    const impact = parsed.impact;
+    const confidence = parsed.confidence;
+    const effort = parsed.effort;
+
+    if (
+      !Number.isInteger(impact) ||
+      !Number.isInteger(confidence) ||
+      !Number.isInteger(effort)
+    ) {
+      throw this.createAiUnavailableError(
+        'Invalid AI payload: expected integer ICE fields',
+      );
+    }
+
+    return {
+      impact: Number(impact),
+      confidence: Number(confidence),
+      effort: Number(effort),
+    };
+  }
+
+  /**
+   * Creates the standardized domain error for external AI failures.
+   * @param message Human-readable failure detail.
+   * @returns Domain exception mapped later to HTTP 502.
+   */
+  private createAiUnavailableError(message: string): DomainException {
+    return new DomainException(
+      message,
+      ERROR_CODES.AI_UNAVAILABLE,
+      HttpStatus.BAD_GATEWAY,
+    );
   }
 }

--- a/src/modules/tasks/tasks-ice.controller.ts
+++ b/src/modules/tasks/tasks-ice.controller.ts
@@ -1,7 +1,14 @@
 /**
  * Groups ICE-related task routes under the /tasks/:id namespace.
  */
-import { Body, Controller, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+} from '@nestjs/common';
 import type { TaskRecord } from './ports/task-repository.port';
 import { ManualIceDto } from './dto/manual-ice.dto';
 import { TasksService } from './tasks.service';
@@ -31,18 +38,13 @@ export class TasksIceController {
   }
 
   /**
-   * Placeholder endpoint for AI ICE estimation route wiring (Fase 5).
+   * Estimates ICE values through the AI provider and persists the result.
    * @param id Task identifier from route parameter.
-   * @returns Route readiness payload.
+   * @returns Updated task with AI-estimated ICE values and source metadata.
    */
   @Post('estimate')
-  public estimateIce(@Param('id') id: string): {
-    readonly taskId: string;
-    readonly route: string;
-  } {
-    return {
-      taskId: id,
-      route: 'estimate',
-    };
+  @HttpCode(HttpStatus.OK)
+  public estimateIce(@Param('id') id: string): Promise<TaskRecord> {
+    return this.tasksService.estimateIceWithAi(id);
   }
 }

--- a/src/modules/tasks/tasks.module.ts
+++ b/src/modules/tasks/tasks.module.ts
@@ -3,6 +3,7 @@
  */
 import { Module } from '@nestjs/common';
 import { IceModule } from '../ice/ice.module';
+import { AiModule } from '../ai/ai.module';
 import { PrismaModule } from '../../infrastructure/persistence/prisma/prisma.module';
 import { PrismaTaskRepository } from '../../infrastructure/persistence/prisma/prisma-task.repository';
 import { TASK_REPOSITORY_PORT } from './ports/task-repository.port';
@@ -11,7 +12,7 @@ import { TasksIceController } from './tasks-ice.controller';
 import { TasksService } from './tasks.service';
 
 @Module({
-  imports: [PrismaModule, IceModule],
+  imports: [PrismaModule, IceModule, AiModule],
   controllers: [TasksController, TasksIceController],
   providers: [
     TasksService,

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -2,6 +2,7 @@
  * Orchestrates task-related use cases for the Tasks module.
  */
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { AiService } from '../ai/ai.service';
 import { IceService } from '../ice/ice.service';
 import { TASK_REPOSITORY_PORT } from './ports/task-repository.port';
 import type {
@@ -16,13 +17,15 @@ import type { ManualIceDto } from './dto/manual-ice.dto';
 @Injectable()
 export class TasksService {
   /**
-   * Creates TasksService with repository and ICE domain dependencies.
+   * Creates TasksService with repository and domain dependencies.
    * @param taskRepositoryPort Abstract repository for task persistence.
+   * @param aiService Application service for external AI estimation.
    * @param iceService Domain service for ICE score calculation and validation.
    */
   public constructor(
     @Inject(TASK_REPOSITORY_PORT)
     private readonly taskRepositoryPort: TaskRepositoryPort,
+    private readonly aiService: AiService,
     private readonly iceService: IceService,
   ) {}
 
@@ -147,6 +150,41 @@ export class TasksService {
       effort: dto.effort,
       iceScore,
       iceSource: 'MANUAL',
+    });
+
+    if (updatedTask === null) {
+      throw new NotFoundException('Task not found');
+    }
+
+    return updatedTask;
+  }
+
+  /**
+   * Estimates ICE values with the AI provider, clamps them through IceService,
+   * calculates the final score and persists the result with AI source.
+   * @param id Task identifier.
+   * @returns Updated task with AI-estimated ICE values.
+   */
+  public async estimateIceWithAi(id: string): Promise<TaskRecord> {
+    const task = await this.getTaskByIdOrThrow(id);
+    const estimation = await this.aiService.estimateIce(task.description);
+    const clampedValues = this.iceService.clampValues(
+      estimation.impact,
+      estimation.confidence,
+      estimation.effort,
+    );
+    const iceScore = this.iceService.calculateScore(
+      clampedValues.impact,
+      clampedValues.confidence,
+      clampedValues.effort,
+    );
+
+    const updatedTask = await this.taskRepositoryPort.update(id, {
+      impact: clampedValues.impact,
+      confidence: clampedValues.confidence,
+      effort: clampedValues.effort,
+      iceScore,
+      iceSource: 'AI',
     });
 
     if (updatedTask === null) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -23,6 +23,22 @@ interface TaskResponse {
   readonly updatedAt: string;
 }
 
+interface GeminiApiSuccessResponse {
+  readonly candidates: readonly [
+    {
+      readonly content: {
+        readonly parts: readonly [
+          {
+            readonly text: string;
+          },
+        ];
+      };
+    },
+  ];
+}
+
+type FetchMock = jest.Mock<Promise<Response>, Parameters<typeof fetch>>;
+
 /**
  * Returns the HTTP server handle with the type expected by supertest.
  * @param app Initialized Nest application.
@@ -118,8 +134,16 @@ async function waitForTimestampTick(): Promise<void> {
 describe('Tasks listing (e2e)', () => {
   let app: INestApplication;
   let prismaService: PrismaService;
+  let fetchMock: FetchMock;
+  const originalFetch = global.fetch;
 
   beforeAll(async () => {
+    process.env.GEMINI_API_KEY = 'test-gemini-key';
+    process.env.GEMINI_MODEL = 'gemini-test-model';
+    process.env.AI_TIMEOUT_MS = '100';
+    fetchMock = jest.fn<Promise<Response>, Parameters<typeof fetch>>();
+    global.fetch = fetchMock as typeof fetch;
+
     const testApplication = await createTestApplication();
 
     app = testApplication.app;
@@ -128,9 +152,11 @@ describe('Tasks listing (e2e)', () => {
 
   beforeEach(async () => {
     await prismaService.task.deleteMany();
+    fetchMock.mockReset();
   });
 
   afterAll(async () => {
+    global.fetch = originalFetch;
     await app.close();
   });
 
@@ -176,5 +202,98 @@ describe('Tasks listing (e2e)', () => {
         ]);
         expect(body.map((task) => task.iceScore)).toEqual([1000, 60, 60, 10]);
       });
+  });
+
+  it('estimates ICE with AI and persists the clamped result', async () => {
+    const task = await createTask(app, 'ai estimated task');
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: '{"impact":11,"confidence":8,"effort":0}',
+                  },
+                ],
+              },
+            },
+          ],
+        } satisfies GeminiApiSuccessResponse),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    await request(getHttpServer(app))
+      .post(`/tasks/${task.id}/ice/estimate`)
+      .expect(200)
+      .expect(({ body }: { readonly body: TaskResponse }) => {
+        expect(body.impact).toBe(10);
+        expect(body.confidence).toBe(8);
+        expect(body.effort).toBe(1);
+        expect(body.iceScore).toBe(800);
+        expect(body.iceSource).toBe('AI');
+      });
+  });
+
+  it('returns 404 when AI estimation targets a missing task', async () => {
+    await request(getHttpServer(app))
+      .post('/tasks/missing-task/ice/estimate')
+      .expect(404)
+      .expect(({ body }: { readonly body: { readonly error: string } }) => {
+        expect(body.error).toBe('NOT_FOUND');
+      });
+  });
+
+  it('returns 502 when the AI provider payload is invalid', async () => {
+    const task = await createTask(app, 'invalid ai payload task');
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: '{"impact":"invalid","confidence":8}',
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    await request(getHttpServer(app))
+      .post(`/tasks/${task.id}/ice/estimate`)
+      .expect(502)
+      .expect(
+        ({
+          body,
+        }: {
+          readonly body: {
+            readonly error: string;
+            readonly message: string;
+          };
+        }) => {
+          expect(body.error).toBe('AI_UNAVAILABLE');
+          expect(body.message).toContain('Invalid AI payload');
+        },
+      );
   });
 });


### PR DESCRIPTION
## Summary
Adds AI-based ICE estimation through `POST /tasks/:id/ice/estimate`
using the task description as provider input and persisting the
calculated task values with `iceSource=ai`.
Maps invalid payloads and timeouts to `502 AI_UNAVAILABLE` and
covers success, 404, and failure scenarios with end-to-end tests.

## Issue
Closes #5

## Target Branch Policy (required)
- [x] This PR targets `dev` if it comes from `feature/*`, `fix/*`, `chore/*`, or `hotfix/*`
- [ ] This PR targets `main` only when source branch is `dev`

## Validation
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test`

## Notes
N/A
